### PR TITLE
Adding ability to use lifetimes in the dispatcher

### DIFF
--- a/actionable-macros/src/dispatcher.rs
+++ b/actionable-macros/src/dispatcher.rs
@@ -52,7 +52,8 @@ impl ToTokens for Dispatcher {
 
         let actionable = actionable(args.actionable.clone(), type_name.span());
 
-        let (impl_generics, type_generics, where_clause) = self.generics.split_for_impl();
+        let (impl_generics_from_split, type_generics, where_clause) =
+            self.generics.split_for_impl();
 
         for enum_type in &args.inputs {
             let generated_dispatcher_name = syn::Ident::new(
@@ -60,10 +61,53 @@ impl ToTokens for Dispatcher {
                 type_name.span(),
             );
 
+            let input_lifetimes = path_lifetimes(enum_type);
+            let (dispatcher_lifetimes, dispatcher_trait_lifetime) =
+                if let Some(lifetimes) = &input_lifetimes {
+                    (quote! {<#(#lifetimes),*>}, quote! {#(#lifetimes),*})
+                } else {
+                    (TokenStream::default(), TokenStream::default())
+                };
+            let impl_generics = match (self.generics.params.is_empty(), input_lifetimes) {
+                (true, lifetimes) => {
+                    if let Some(lifetimes) = lifetimes {
+                        quote! {<#(#lifetimes),*>}
+                    } else {
+                        TokenStream::default()
+                    }
+                }
+                (false, Some(lifetimes)) => {
+                    let generic_args = self
+                        .generics
+                        .params
+                        .iter()
+                        .map(|generic| match generic {
+                            syn::GenericParam::Type(ty) => ty.ident.to_token_stream(),
+                            syn::GenericParam::Lifetime(lifetime) => {
+                                let lifetime = &lifetime.lifetime;
+                                quote! {#lifetime}
+                            }
+                            syn::GenericParam::Const(constant) => {
+                                let name = &constant.ident;
+                                quote! {const #name}
+                            }
+                        })
+                        .chain(lifetimes.into_iter().map(ToTokens::into_token_stream));
+                    quote! {<#(#generic_args),*>}
+                }
+                (false, None) => impl_generics_from_split.to_token_stream(),
+            };
+
+            let dispatcher_generics = if dispatcher_trait_lifetime.is_empty() {
+                quote!('static, #enum_type)
+            } else {
+                quote!(#dispatcher_trait_lifetime, #enum_type)
+            };
+
             tokens.extend(quote! {
                 #[#actionable::async_trait]
-                impl#impl_generics #actionable::Dispatcher<#enum_type> for #type_name#type_generics #where_clause {
-                    type Result = Result<<Self as #generated_dispatcher_name>::Output,<Self as #generated_dispatcher_name>::Error>;
+                impl#impl_generics #actionable::Dispatcher<#dispatcher_generics> for #type_name#type_generics #where_clause {
+                    type Result = Result<<Self as #generated_dispatcher_name#dispatcher_lifetimes>::Output,<Self as #generated_dispatcher_name#dispatcher_lifetimes>::Error>;
 
                     async fn dispatch(&self, permissions: &#actionable::Permissions, request: #enum_type) -> Self::Result {
                         #generated_dispatcher_name::dispatch_to_handlers(self, permissions, request).await
@@ -103,5 +147,31 @@ impl Parse for Arg {
             "input" => Ok(Self::Input(input.parse()?)),
             _ => abort!(ident, "unknown parameter"),
         }
+    }
+}
+
+fn path_lifetimes(path: &syn::Path) -> Option<Vec<syn::Lifetime>> {
+    let last_path_args = &path
+        .segments
+        .last()
+        .expect("expected at least one path segment in type path")
+        .arguments;
+
+    if let syn::PathArguments::AngleBracketed(bracketed) = last_path_args {
+        Some(
+            bracketed
+                .args
+                .iter()
+                .filter_map(|generic| {
+                    if let syn::GenericArgument::Lifetime(lifetime) = generic {
+                        Some(lifetime.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+        )
+    } else {
+        None
     }
 }

--- a/actionable/src/dispatcher.rs
+++ b/actionable/src/dispatcher.rs
@@ -5,11 +5,13 @@ use crate::Permissions;
 
 /// Dispatches `T` to an appropriate handler. This trait is derivable.
 #[async_trait]
-pub trait Dispatcher<T>: Send + Sync {
+pub trait Dispatcher<'a, T: 'a>: Send + Sync {
     /// The type of the result.
     type Result: Send + Sync;
 
     /// Dispatches `request` to the appropriate handler while also ensuring
     /// `permissions` allows the request.
-    async fn dispatch(&self, permissions: &Permissions, request: T) -> Self::Result;
+    async fn dispatch(&self, permissions: &Permissions, request: T) -> Self::Result
+    where
+        'a: 'async_trait;
 }

--- a/actionable/src/lib.rs
+++ b/actionable/src/lib.rs
@@ -84,6 +84,7 @@
     future_incompatible,
     rust_2018_idioms
 )]
+#![allow(clippy::no_effect_underscore_binding)] // async_trait false positives
 #![cfg_attr(doc, deny(rustdoc::all))]
 
 mod action;

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,4 +9,3 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 khonsu-tools = { git = "https://github.com/khonsulabs/khonsu-tools.git", branch = "main" }
-structopt = "0.3"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,30 +1,42 @@
 use khonsu_tools::{
-    anyhow,
-    code_coverage::{self, CodeCoverage},
-};
-use structopt::StructOpt;
-
-#[derive(StructOpt, Debug)]
-pub enum Commands {
-    GenerateCodeCoverageReport {
-        #[structopt(long = "install-dependencies")]
-        install_dependencies: bool,
+    publish,
+    universal::{
+        anyhow,
+        clap::Parser,
+        code_coverage::{self},
+        DefaultConfig,
     },
-}
+};
 
 fn main() -> anyhow::Result<()> {
-    let command = Commands::from_args();
-    match command {
-        Commands::GenerateCodeCoverageReport {
-            install_dependencies,
-        } => CodeCoverage::<CoverageConfig>::execute(install_dependencies),
+    khonsu_tools::Commands::parse().execute::<Config>()
+}
+
+struct Config;
+
+impl khonsu_tools::universal::Config for Config {
+    type Audit = DefaultConfig;
+
+    type CodeCoverage = Self;
+}
+
+impl khonsu_tools::Config for Config {
+    type Publish = Self;
+
+    type Universal = Self;
+}
+
+impl code_coverage::Config for Config {
+    fn ignore_paths() -> Vec<String> {
+        vec![String::from("actionable/examples/*")]
     }
 }
 
-struct CoverageConfig;
-
-impl code_coverage::Config for CoverageConfig {
-    fn ignore_paths() -> Vec<String> {
-        vec![String::from("actionable/examples/*")]
+impl publish::Config for Config {
+    fn paths() -> Vec<String> {
+        vec![
+            String::from("actionable-macros"),
+            String::from("actionable"),
+        ]
     }
 }


### PR DESCRIPTION
This is an effort to try to re-introduce lifetimes on Document in BonsaiDb. I yanked them when introducing serde_bytes because I discovered the bytes weren't actually being borrowed. Yesterday I went to try to reintroduce it and ran into this limitation. I'm hopeful this will enable less copies during network requests within BonsaiDb.